### PR TITLE
bugfix: 추론 결과가 이상하게 나오는 문제

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -13,4 +13,4 @@ HALF: false
 KEPT_MODEL_TYPE: "hrnet"
 KEPT_MODEL_PATH: './weights/hrnet_merge_w48_384x288.pth'
 KEPT_HALF: false
-KEPT_IMG_SIZE: [384, 288]
+KEPT_IMG_SIZE: [288, 384]

--- a/detectors/hrnet.py
+++ b/detectors/hrnet.py
@@ -157,7 +157,7 @@ class HRNet(nn.Module):
         center[0] = top_left_x + box_width * 0.5
         center[1] = top_left_y + box_height * 0.5
 
-        aspect_ratio = self.img_size[0] * 1.0 / self.img_size[0]
+        aspect_ratio = self.img_size[0] * 1.0 / self.img_size[1]
         pixel_std = 200
 
         if box_width > aspect_ratio * box_height:


### PR DESCRIPTION
image size의 order 가 꼬여서 hrnet 전처리 상 문제발생이 원인
순서는 width, height 순서로 고정